### PR TITLE
加舊地名漢字看覓

### DIFF
--- a/教典/匯入資料.py
+++ b/教典/匯入資料.py
@@ -44,6 +44,8 @@ class 教典字物件:
                 for row in DictReader(資料):
                     if '地名' not in row['屬性'].strip():
                         會使的屬性.add(row['編號'].strip())
+                    elif '舊地名' in row['屬性'].strip():
+                        會使的屬性.add(row['編號'].strip())
         with urlopen(cls.詞目總檔網址) as 檔:
             with io.StringIO(檔.read().decode()) as 資料:
                 for row in DictReader(資料):


### PR DESCRIPTION
結果
```
/用字$ diff kautian.json 教典.json  
131a132
>   "乾｜ta1",
190a192
>   "他｜ta1",
562a565
>   "凹｜au7",
1019a1023
>   "哆｜to1",
1020a1025
>   "哈｜ha2",
1074a1080
>   "唭｜ki3",
1184a1191
>   "嗹｜lian1",
1220a1228
>   "噍｜ta1",
1246a1255
>   "噶｜kat4",
1345a1355
>   "坌｜hun1",
1407a1418
>   "堀｜khut4",
1441a1453
>   "塹｜tsham3",
1475a1488,1489
>   "壟｜lang1",
>   "壟｜lang5",
1937a1952
>   "崙｜lun1",
1941a1957
>   "嵌｜kham3",
1942a1959
>   "嵙｜khoo1",
1944a1962
>   "嶠｜kiau1",
1951a1970
>   "巖｜giam5",
2101a2121
>   "弄｜long3",
2134a2155
>   "彌｜bi5",
2639a2661
>   "挖｜uat4",
2833a2856
>   "搭｜ta7",
3424a3448
>   "梘｜king2",
3533a3558
>   "槓｜khong5",
3839a3865,3866
>   "泵｜pong7",
>   "洄｜hue5",
3875a3903
>   "浪｜lang5",
4050a4079
>   "澗｜kan2",
4063a4093
>   "濃｜long1",
4085a4116
>   "瀾｜lian5",
4371a4403
>   "玲｜lin5",
4377a4410
>   "珞｜lok8",
4410a4444
>   "瑯｜long5",
4803a4838
>   "硿｜kng2",
5045a5081
>   "笨｜pun3",
5421a5458
>   "罵｜ma5",
5475a5513
>   "老｜loo7",
5661a5700
>   "腳｜kha1",
5782a5822
>   "舺｜kah4",
5783a5824
>   "艋｜bang2",
5967a6009
>   "萣｜tiann7",
6056a6099
>   "蕃｜han1",
6146a6190
>   "蘭｜lan2",
6173a6218
>   "蚊｜bang2",
6342a6388
>   "衛｜ue2",
6989a7036
>   "返｜tng2",
7257a7305
>   "鋉｜sok4",
7414a7463
>   "陀｜lo5",
7415a7465
>   "陂｜pi1",
7519a7570
>   "霄｜siau1",
7534a7586
>   "霧｜buh4",
7934a7987
>   "鷺｜loo5",
8027a8081
>   "龍｜long5",
```