### PR TITLE
解決Django secret keys should not be disclosed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     tai5-uan5_gian5-gi2_kang1-ku7
     coverage
 setenv =
-    SECRET_KEY = tshi3-giam7#iong7
+    SECRET_KEY = tshi3-giam7_iong7
 commands =
     coverage run --source=用字 manage.py test {posargs}
     coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     django
     tai5-uan5_gian5-gi2_kang1-ku7
     coverage
+setenv =
+    SECRET_KEY = tshi3-giam7#iong7
 commands =
     coverage run --source=用字 manage.py test {posargs}
     coverage xml

--- a/設定/settings.py
+++ b/設定/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY', '')
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/設定/settings.py
+++ b/設定/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'w+1)*(lenpu5h=n)mas3w8s(&ojc(l^vs(-qrvykwi$09mds6m'
+SECRET_KEY = os.getenv('SECRET_KEY', '')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## 情形

監控dependencybot https://github.com/i3thuan5/KauTian-IongJi/security/code-scanning/1

## 解法

試驗用SECRET_KEY改uì TOX傳來。